### PR TITLE
Truncate contact info

### DIFF
--- a/app/templates/relay_consensus.html
+++ b/app/templates/relay_consensus.html
@@ -1,7 +1,7 @@
 {% set fingerprint = family["families"][0]["fingerprint"] %}
 <tr onclick="window.document.location='/family_detail/{{fingerprint}}';" style="cursor: pointer; cursor: hand; height: 3.5em;">
   <td class="text-center;" style="vertical-align: middle;">{{ rank_consensus }}</td>
-  <td style="width: 20%; vertical-align: middle";>{{ family["contact"][0] }}</th>
+  <td style="width: 20%; vertical-align: middle";>{{ family["contact"][0] | truncate(40) }}</th>
   <td>{{ family["consensus_points"] | int() }}</td>
   <td class="text-right" style="width: 20%; vertical-align: middle;">{{ family["consensus_weight"]}} ({{ "%.3f" | format(family["consensus_weight_fraction"] * 100) }}%)</td>
   <td class="text-center" style="vertical-align: middle;">{{ family["families"] | length }}</td>


### PR DESCRIPTION
Currently truncates to final world whose last character is below index 40.

It may be a good idea to make this truncation value a variable specified in views.py  or some other settings file.
